### PR TITLE
Fix typo in repo url

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/fastify/processs-warning.git"
+    "url": "git+https://github.com/fastify/process-warning.git"
   },
   "keywords": [
     "fastify",


### PR DESCRIPTION

#### Checklist

- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
