### PR TITLE
perf: improve performance of emit()

### DIFF
--- a/benchmarks/warn.js
+++ b/benchmarks/warn.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const { Suite } = require('benchmark')
+const warning = require('..')()
+
+warning.create('FastifyWarning', 'FST_ERROR_CODE_1', 'message')
+warning.create('FastifyWarning', 'FST_ERROR_CODE_2', 'message')
+warning.create('FastifyWarning', 'FST_ERROR_CODE_3', 'message')
+new Suite()
+  .add('warn', function () {
+    warning.emit('FST_ERROR_CODE_1')
+    warning.emit('FST_ERROR_CODE_3')
+  })
+  .on('cycle', function (event) {
+    console.log(String(event.target))
+  })
+  .run()

--- a/index.js
+++ b/index.js
@@ -44,8 +44,8 @@ function build () {
   }
 
   function emit (code, a, b, c) {
-    if (codes[code] === undefined) throw new Error(`The code '${code}' does not exist`)
     if (emitted.get(code) === true) return
+    if (codes[code] === undefined) throw new Error(`The code '${code}' does not exist`)
     emitted.set(code, true)
 
     const warning = codes[code](a, b, c)

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "homepage": "https://github.com/fastify/fastify-warning#readme",
   "devDependencies": {
+    "benchmark": "^2.1.4",
     "jest": "^29.0.1",
     "standard": "^17.0.0",
     "tap": "^16.3.0",


### PR DESCRIPTION
Follow Up of #69 

As @climba03003 correctly concluded, checking first if we already emitted the warning is actually the performance gain. So we put that to the fast-path.

before:
```sh
uzlopak@Battlestation:~/workspace/fastify-org/process-warning$ node benchmarks/warn.js
warn x 40,120,473 ops/sec ±0.64% (98 runs sampled)
(node:9821) [FST_ERROR_CODE_1] FastifyWarning: message
(Use `node --trace-warnings ...` to show where the warning was created)
(node:9821) [FST_ERROR_CODE_3] FastifyWarning: message
```

after:

```sh
uzlopak@Battlestation:~/workspace/fastify-org/process-warning$ node benchmarks/warn.js
warn x 90,812,134 ops/sec ±0.27% (94 runs sampled)
(node:9882) [FST_ERROR_CODE_1] FastifyWarning: message
(Use `node --trace-warnings ...` to show where the warning was created)
(node:9882) [FST_ERROR_CODE_3] FastifyWarning: message
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
