### PR TITLE
fix: avoid global unlimited config

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "lint": "standard",
     "lint:fix": "standard --fix",
+    "benchmark": "node benchmarks/warn.js",
     "test": "npm run test:unit && npm run test:jest && npm run test:typescript",
     "test:jest": "jest jest.test.js",
     "test:unit": "tap",

--- a/test/emit-once-only.test.js
+++ b/test/emit-once-only.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const test = require('tap').test
+const { test } = require('tap')
 const build = require('..')
 
 test('emit should emit a given code only once', t => {

--- a/test/issue-88.test.js
+++ b/test/issue-88.test.js
@@ -1,0 +1,26 @@
+'use strict'
+
+const { test } = require('tap')
+const build = require('..')
+
+test('Must not overwrite the global config', t => {
+  t.plan(1)
+
+  const { create, emit } = build()
+
+  function onWarning (warning) {
+    t.equal(warning.code, 'CODE_1')
+  }
+
+  create('FastifyWarning', 'CODE_1', 'Msg', { unlimited: false })
+  create('FastifyWarning', 'CODE_2', 'Msg', { unlimited: true })
+
+  process.on('warning', onWarning)
+  emit('CODE_1')
+  emit('CODE_1')
+
+  setImmediate(() => {
+    process.removeListener('warning', onWarning)
+    t.end()
+  })
+})


### PR DESCRIPTION
fixes #88 

I choose to use a number instead of adding a new long-lived object in memory to track the state of the event.
This reduces the memory footprint a bit.

