### PR TITLE
fix: emitter api

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -1,2 +1,3 @@
 files:
   - test/**/*[!jest].test.js
+  - test/lib/*.test.js

--- a/index.js
+++ b/index.js
@@ -75,11 +75,13 @@ class STATE extends Boolean {
     this.#code = val
   }
 
+  /* istanbul ignore next */
   isEmitted () {
     return this.valueOf()
   }
 
   valueOf () {
+    /* istanbul ignore next */
     switch (this.#code) {
       case STATE.UNLIMITED_INITIAL: return false
       case STATE.UNLIMITED_ONGOING: return true

--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ const STATES = {
   UNLIMITED_INITIAL: newBooleanState(0),
   UNLIMITED_ONGOING: newBooleanState(-1),
   LIMITED_INITIAL: newBooleanState(1),
-  LIMITED_FINAL: newBooleanState(2),
+  LIMITED_FINAL: newBooleanState(2)
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { format } = require('node:util')
+const STATE = require('./lib/bool-state')
 
 /**
  * An object that provides methods for creating process warning, emitting them,
@@ -34,62 +35,6 @@ const { format } = require('node:util')
  * @param {*} [param3] Third possible string interpolation value.
  * @returns ProcessWarning
  */
-
-/**
- * @typedef {number} STATE_CONSTANT
- */
-
-/**
- * @private
- * @typdef {object} EMISSION_STATES
- * @property {STATE_CONSTANT} UNLIMITED_INITIAL Indicates that the warning
- * is to be issued an unlimited number of times but has not yet been
- * emitted.
- * @property {STATE_CONSTANT} UNLIMITED_ONGOING Indicates that the warning
- * is to be issued an unlimited number of times and has been emitted at least
- * once.
- * @property {STATE_CONSTANT} LIMITED_INITIAL Indicates that the warning
- * is to be issued only once but has not yet been emitted.
- * @property {STATE_CONSTANT} LIMITED_FINAL Indicates that the warning
- * is to be issued only once and has already been emitted.
- */
-
-class STATE extends Boolean {
-  static UNLIMITED_INITIAL = 0
-  static UNLIMITED_ONGOING = -1
-  static LIMITED_INITIAL = 1
-  static LIMITED_FINAL = 2
-
-  #code = 0
-
-  constructor (value) {
-    super()
-    this.#code = value ?? 0
-  }
-
-  get code () {
-    return this.#code
-  }
-
-  set code (val) {
-    this.#code = val
-  }
-
-  /* istanbul ignore next */
-  isEmitted () {
-    return this.valueOf()
-  }
-
-  valueOf () {
-    /* istanbul ignore next */
-    switch (this.#code) {
-      case STATE.UNLIMITED_INITIAL: return false
-      case STATE.UNLIMITED_ONGOING: return true
-      case STATE.LIMITED_INITIAL: return false
-      case STATE.LIMITED_FINAL: return true
-    }
-  }
-}
 
 /**
  * Factory that builds a new {@link ProcessWarningManager} and returns it.

--- a/index.js
+++ b/index.js
@@ -35,8 +35,7 @@ const { format } = require('node:util')
  * @returns ProcessWarning
  */
 
-
-  /**
+/**
    * @private
    * @typdef {object} EMISSION_STATES
    * @property {STATE_CONSTANT} UNLIMITED_INITIAL Indicates that the warning
@@ -50,12 +49,12 @@ const { format } = require('node:util')
    * @property {STATE_CONSTANT} LIMITED_FINAL Indicates that the warning
    * is to be issued only once and has already been emitted.
    */
-  const STATES = {
-    UNLIMITED_INITIAL: 0,
-    UNLIMITED_ONGOING: -1,
-    LIMITED_INITIAL: 1,
-    LIMITED_FINAL: 2
-  }
+const STATES = {
+  UNLIMITED_INITIAL: 0,
+  UNLIMITED_ONGOING: -1,
+  LIMITED_INITIAL: 1,
+  LIMITED_FINAL: 2
+}
 
 /**
  * Factory that builds a new {@link ProcessWarningManager} and returns it.
@@ -66,7 +65,7 @@ function processWarning () {
   const codes = {}
   const emitted = new Map()
 
-/**
+  /**
  * @typedef {number} STATE_CONSTANT
  */
 

--- a/lib/bool-state.js
+++ b/lib/bool-state.js
@@ -1,0 +1,56 @@
+'use strict'
+
+/**
+ * @typedef {number} STATE_CONSTANT
+ */
+
+/**
+ * @private
+ * @typdef {object} EMISSION_STATES
+ * @property {STATE_CONSTANT} UNLIMITED_INITIAL Indicates that the warning
+ * is to be issued an unlimited number of times but has not yet been
+ * emitted.
+ * @property {STATE_CONSTANT} UNLIMITED_ONGOING Indicates that the warning
+ * is to be issued an unlimited number of times and has been emitted at least
+ * once.
+ * @property {STATE_CONSTANT} LIMITED_INITIAL Indicates that the warning
+ * is to be issued only once but has not yet been emitted.
+ * @property {STATE_CONSTANT} LIMITED_FINAL Indicates that the warning
+ * is to be issued only once and has already been emitted.
+ */
+class STATE extends Boolean {
+  static UNLIMITED_INITIAL = 0
+  static UNLIMITED_ONGOING = -1
+  static LIMITED_INITIAL = 1
+  static LIMITED_FINAL = 2
+
+  #code = 0
+
+  constructor (value) {
+    super()
+    this.#code = value ?? 0
+  }
+
+  get code () {
+    return this.#code
+  }
+
+  set code (val) {
+    this.#code = val
+  }
+
+  isEmitted () {
+    return this.valueOf()
+  }
+
+  valueOf () {
+    switch (this.#code) {
+      case STATE.UNLIMITED_INITIAL: return false
+      case STATE.UNLIMITED_ONGOING: return true
+      case STATE.LIMITED_INITIAL: return false
+      case STATE.LIMITED_FINAL: return true
+    }
+  }
+}
+
+module.exports = STATE

--- a/test/emitter-object.test.js
+++ b/test/emitter-object.test.js
@@ -3,28 +3,53 @@
 const { test } = require('tap')
 const build = require('../')
 
-test('emitted is a map<string, bool> object', t => {
+test('emitted is a map<string, bool-like> object', t => {
   t.plan(8)
 
   const { emitted } = build()
-  t.equal(emitted.get('CODE'), false, 'not set yet')
+  t.notOk(emitted.get('CODE'), 'not set yet')
 
   emitted.set('CODE', true)
-  t.equal(emitted.get('CODE'), true, 'set to true')
+  t.ok(emitted.get('CODE'), 'set to true')
 
   emitted.set('CODE', false)
-  t.equal(emitted.get('CODE'), false, 'set to false')
+  t.notOk(emitted.get('CODE'), 'set to false')
 
-  t.equal(emitted.has('CODE'), true, 'has code')
+  t.ok(emitted.has('CODE'), 'has code')
 
   emitted.delete('CODE')
-  t.equal(emitted.get('CODE'), false, 'deleted')
-  t.equal(emitted.has('CODE'), false, 'has code')
+  t.notOk(emitted.get('CODE'), 'deleted')
+  t.notOk(emitted.has('CODE'), 'does not has code')
 
   emitted.set('CODE', true)
   emitted.set('CODE', true)
-  t.equal(emitted.get('CODE'), true, 'set to true twice')
+  t.ok(emitted.get('CODE'), 'set to true twice')
 
   emitted.clear()
-  t.equal(emitted.get('CODE'), false, 'cleared')
+  t.notOk(emitted.get('CODE'), 'cleared')
+})
+
+test('state is a bool-like', t => {
+  t.plan(8)
+
+  const { emitted, emit, create } = build()
+
+  create('CODE', 'CODE', 'Hello %s')
+  create('CODE', 'CODE_UNLIMITED', 'Hello %s', { unlimited: true })
+  // eslint-disable-next-line
+  t.ok(emitted.get('CODE') == false, 'not called yet (coerced)')
+  // eslint-disable-next-line
+  t.ok(emitted.get('CODE_UNLIMITED') == false, 'not called yet (coerced)')
+  t.notOk(emitted.get('CODE').isEmitted(), 'not called yet')
+  t.notOk(emitted.get('CODE_UNLIMITED').isEmitted(), 'not called yet')
+
+  emit('CODE', 'world')
+  emit('CODE_UNLIMITED', 'world')
+
+  // eslint-disable-next-line
+  t.ok(emitted.get('CODE') == true, 'set to true (coerced)')
+  // eslint-disable-next-line
+  t.ok(emitted.get('CODE_UNLIMITED') == true, 'set to true (coerced)')
+  t.ok(emitted.get('CODE').isEmitted(), 'set to true')
+  t.ok(emitted.get('CODE_UNLIMITED').isEmitted(), 'set to true')
 })

--- a/test/emitter-object.test.js
+++ b/test/emitter-object.test.js
@@ -1,0 +1,30 @@
+'use strict'
+
+const { test } = require('tap')
+const build = require('../')
+
+test('emitted is a map<string, bool> object', t => {
+  t.plan(8)
+
+  const { emitted } = build()
+  t.equal(emitted.get('CODE'), false, 'not set yet')
+
+  emitted.set('CODE', true)
+  t.equal(emitted.get('CODE'), true, 'set to true')
+
+  emitted.set('CODE', false)
+  t.equal(emitted.get('CODE'), false, 'set to false')
+
+  t.equal(emitted.has('CODE'), true, 'has code')
+
+  emitted.delete('CODE')
+  t.equal(emitted.get('CODE'), false, 'deleted')
+  t.equal(emitted.has('CODE'), false, 'has code')
+
+  emitted.set('CODE', true)
+  emitted.set('CODE', true)
+  t.equal(emitted.get('CODE'), true, 'set to true twice')
+
+  emitted.clear()
+  t.equal(emitted.get('CODE'), false, 'cleared')
+})

--- a/test/emitter-object.test.js
+++ b/test/emitter-object.test.js
@@ -28,28 +28,3 @@ test('emitted is a map<string, bool-like> object', t => {
   emitted.clear()
   t.notOk(emitted.get('CODE'), 'cleared')
 })
-
-test('state is a bool-like', t => {
-  t.plan(8)
-
-  const { emitted, emit, create } = build()
-
-  create('CODE', 'CODE', 'Hello %s')
-  create('CODE', 'CODE_UNLIMITED', 'Hello %s', { unlimited: true })
-  // eslint-disable-next-line
-  t.ok(emitted.get('CODE') == false, 'not called yet (coerced)')
-  // eslint-disable-next-line
-  t.ok(emitted.get('CODE_UNLIMITED') == false, 'not called yet (coerced)')
-  t.notOk(emitted.get('CODE').isEmitted(), 'not called yet')
-  t.notOk(emitted.get('CODE_UNLIMITED').isEmitted(), 'not called yet')
-
-  emit('CODE', 'world')
-  emit('CODE_UNLIMITED', 'world')
-
-  // eslint-disable-next-line
-  t.ok(emitted.get('CODE') == true, 'set to true (coerced)')
-  // eslint-disable-next-line
-  t.ok(emitted.get('CODE_UNLIMITED') == true, 'set to true (coerced)')
-  t.ok(emitted.get('CODE').isEmitted(), 'set to true')
-  t.ok(emitted.get('CODE_UNLIMITED').isEmitted(), 'set to true')
-})

--- a/test/lib/bool-state.test.js
+++ b/test/lib/bool-state.test.js
@@ -1,0 +1,35 @@
+'use strict'
+
+const tap = require('tap')
+const STATE = require('../../lib/bool-state')
+
+tap.test('code returns a state code', async t => {
+  const state = new STATE()
+  t.equal(state.code, STATE.UNLIMITED_INITIAL)
+
+  for (let i = -1; i < 3; i += 1) {
+    const state = new STATE(i)
+    t.equal(state.code, i)
+  }
+})
+
+tap.test('code can be set', async t => {
+  const state = new STATE(STATE.LIMITED_INITIAL)
+  t.equal(state.code, STATE.LIMITED_INITIAL)
+  state.code = STATE.LIMITED_FINAL
+  t.equal(state.code, STATE.LIMITED_FINAL)
+})
+
+tap.test('isEmitted returns primitive', async t => {
+  const state = new STATE(STATE.LIMITED_INITIAL)
+  t.equal(state.isEmitted(), false)
+
+  state.code = STATE.LIMITED_FINAL
+  t.equal(state.isEmitted(), true)
+
+  state.code = STATE.UNLIMITED_INITIAL
+  t.equal(state.isEmitted(), false)
+
+  state.code = STATE.UNLIMITED_ONGOING
+  t.equal(state.isEmitted(), true)
+})


### PR DESCRIPTION
right now fastify relies on `emitter` as a map of string/bool.

This pr exposes that interface "officially"

Ref:

- https://github.com/fastify/fastify/pull/5051
- https://github.com/fastify/fastify/pull/5051#issuecomment-1817843994

Bench best of 3 run:

```
➜  process-warning git:(fix-map-api) ✗ node benchmarks/warn.js
warn x 104,268,444 ops/sec ±0.56% (97 runs sampled)
(node:21139) [FST_ERROR_CODE_1] FastifyWarning: message
(Use `node --trace-warnings ...` to show where the warning was created)
(node:21139) [FST_ERROR_CODE_3] FastifyWarning: message
```

```
➜  process-warning git:(master) node benchmarks/warn.js
warn x 103,022,188 ops/sec ±0.31% (101 runs sampled)
(node:21559) [FST_ERROR_CODE_1] FastifyWarning: message
(Use `node --trace-warnings ...` to show where the warning was created)
(node:21559) [FST_ERROR_CODE_3] FastifyWarning: message
```


