### PR TITLE
build(deps-dev): add eslint, peer dep of neostandard

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@fastify/pre-commit": "^2.1.0",
     "benchmark": "^2.1.4",
+    "eslint": "^9.17.0",
     "jest": "^29.7.0",
     "neostandard": "^0.12.0",
     "tap": "^18.7.2",


### PR DESCRIPTION
Missing peer dep. This is a batch PR, so may have some issues. Please review changes.