### PR TITLE
ci: remove node16 and 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,4 +20,3 @@ jobs:
     with:
       license-check: true
       lint: true
-      node-versions: '["16", "18", "20", "22"]'


### PR DESCRIPTION
Same as https://github.com/fastify/fast-content-type-parse/pull/47

Do we want to support node 16 18?
I think this is a leftover from https://github.com/fastify/process-warning/pull/104
and we shipped a wrong version of fastify-workflow, for this reason the pin

cc @gurgunday 